### PR TITLE
Update signing-up.md

### DIFF
--- a/content/docs/account/signing-up.md
+++ b/content/docs/account/signing-up.md
@@ -15,7 +15,7 @@ When you [sign up](https://dashboard.civo.com/signup) to Civo, the system will r
 
 For account security and integrity, Civo requires you to verify your phone number. Before you are able to add a payment method or launch resources in your account, you will need to complete this process.
 
-If you see the "We need you to verify your phone number to complete your sign-up" banner, click the "Verify your numer now" link to access the service.
+If you see the "We need you to verify your phone number to complete your sign-up" banner, click the "Verify your number now" link to access the service.
 
 ![Phone verification input](./images/phone-verification-input.png)
 


### PR DESCRIPTION
I made a change to a typographical error on the "Signing Up" doc page, under the "Verifying your number" Heading. The typographical error can be found in this statement: 'If you see the "We need you to verify your phone number to complete your sign-up" banner, click the "Verify your numer now" link to access the service.' Letter 'b' in "Verify your number" was omitted.